### PR TITLE
Get rid of old cached site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,7 @@ module.exports = config => {
   config.addPassthroughCopy("src/assets/og");
   // deploy favicons at the root for best browser support
   config.addPassthroughCopy({ "src/assets/icons": "/" });
+  config.addPassthroughCopy("src/sw.js");
 
   // needed to merge tags from specific files with directory-level data
   config.setDataDeepMerge(true);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/sw.js"
+  [headers.values]
+    cache-control = "max-age=0,no-cache,no-store,must-revalidate"

--- a/src/_includes/layouts/base.11ty.js
+++ b/src/_includes/layouts/base.11ty.js
@@ -101,6 +101,22 @@ module.exports = data => {
             }
           });
         }
+        // remove all service workers (from the old site)
+        if (navigator.serviceWorker) {
+          navigator.serviceWorker
+            .getRegistrations()
+            .then(function(registrations) {
+              for (let registration of registrations) {
+                registration.unregister();
+              }
+            });
+        }
+        // delete old cached files
+        if (caches) {
+          caches.keys().then(function(names) {
+            for (let name of names) caches.delete(name);
+          });
+        }
       </script>
     </html>
   `;

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,17 @@
+self.addEventListener("install", function() {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", function() {
+  caches.keys().then(function(names) {
+    for (let name of names) caches.delete(name);
+  });
+  self.registration
+    .unregister()
+    .then(function() {
+      return self.clients.matchAll();
+    })
+    .then(function(clients) {
+      clients.forEach(client => client.navigate(client.url));
+    });
+});


### PR DESCRIPTION
## tl;dr fix

The JS code in `base.11ty.js` should unregister the old service worker and delete any old caches. Unfortunately this code will only run if the user visits a _non-cached_ page. If they have previously cached the `index.html` they won't ever get this new code.

Apparently service workers check for updates every 24 hours by default, so I have also included an `sw.js` file served at the root. This matches the old service worker, which means it should be used in place of that one within 24 hours. This new one just unregisters all service workers, deletes the cache and reloads the page.

I've also told Netlify to never cache the service worker file itself, which should hopefully mean users get the updated one sooner.

## Background context

So the old site had a Service Worker (that's an annoying default a lot of Gatsby sites have).

SWs are client-side proxies that intercept all requests. They're designed to be used for offline support (serving files from the cache). The problem we have is that if a user visited the old site its SW will have cached the `index.html`, which means the new page won't display. Some users will see the old site if their cache is good, otherwise they might see an error, as the SW can't reach any of the resources it needs (since the old site files aren't there anymore).

This is only happening if the user goes to `www.foundersandcoders.com`, since that was the primary domain for the old site. The old SW isn't registered for just `foundersandcoders.com`.
