### PR TITLE
Permanently redirect old TFB route to new one

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   for = "/sw.js"
   [headers.values]
     cache-control = "max-age=0,no-cache,no-store,must-revalidate"
+
+[[redirects]]
+  from = "/techforbetter"
+  to = "/tech-for-better"
+  status = 301


### PR DESCRIPTION
The old site used `/techforbetter`, the new one uses `/tech-for-better`. This will permanently redirect the old one to the new on Netlify.