### PR TITLE
Add Netlify badge to footer

### DIFF
--- a/src/_includes/layouts/base.11ty.js
+++ b/src/_includes/layouts/base.11ty.js
@@ -189,6 +189,14 @@ function Footer({ nextPage, site }) {
             © ${new Date().getFullYear()} Founders and Coders. All rights
             reserved.
           </div>
+          <div>
+            <a href="https://www.netlify.com" aria-label="Deploys by Netlify">
+              <img
+                src="https://www.netlify.com/img/global/badges/netlify-light.svg"
+                alt=""
+              />
+            </a>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
To comply with their free open source plan

Not the best looking but I don't have time to redesign the footer atm

<img width="2032" alt="Screenshot 2020-02-19 at 14 15 49" src="https://user-images.githubusercontent.com/9408641/74842619-9b6fa480-5322-11ea-8d1e-be0351d558bb.png">

Fixes #14