### PR TITLE
Rename prerequisites to "application requirements"

### DIFF
--- a/src/_data/cohortDates.json
+++ b/src/_data/cohortDates.json
@@ -3,7 +3,7 @@
     "name": "Spring 2021",
     "dates": [
       {
-        "title": "Prerequisites and application cycle",
+        "title": "Work on your application between",
         "open": "2020-09-01T00:00:00.000Z",
         "close": "2021-01-03T00:00:00.000Z"
       },

--- a/src/pages/documents/postponing-winter.md
+++ b/src/pages/documents/postponing-winter.md
@@ -2,23 +2,23 @@
 title: Postponing winter 2020 cohort
 ---
 
-Hello everyone, 
+Hello everyone,
 
-After some long reflections, conversations and deliberations, we've made the difficult decision to not run a winter cohort this year. We know you must have questions, so please read on. 
+After some long reflections, conversations and deliberations, we've made the difficult decision to not run a winter cohort this year. We know you must have questions, so please read on.
 
-But first, some exciting news. We have recently been accepted onto the Register of Apprenticeship Training Providers, which will open opportunities for some of our students to earn an apprentice wage while they study with us. 
+But first, some exciting news. We have recently been accepted onto the Register of Apprenticeship Training Providers, which will open opportunities for some of our students to earn an apprentice wage while they study with us.
 
 As we sit with this excitement, we also wanted to take this time to reflect back on the last six years...
 
-Founders and Coders has been running our tuition-free coding school since 2014 without a break. With the generous support and volunteer efforts of our alumni community, we have been able to make incremental changes to our curriculum and our organisation with each iteration, but we haven't had the space and energy to make truly effective structural change. 
+Founders and Coders has been running our tuition-free coding school since 2014 without a break. With the generous support and volunteer efforts of our alumni community, we have been able to make incremental changes to our curriculum and our organisation with each iteration, but we haven't had the space and energy to make truly effective structural change.
 
-The transition to providing apprenticeships is going to take much of our attention over the next few months, and is an invaluable opportunity for us to reshape our organisation in ways we haven't been able to before. 
+The transition to providing apprenticeships is going to take much of our attention over the next few months, and is an invaluable opportunity for us to reshape our organisation in ways we haven't been able to before.
 
 We want to be part of the transformation of the tech industry into a more inclusive, equitable and diverse environment. This pause in our programme is an opportunity for us to reflect on our role in this and how we can continue to make it happen.
 
-While we have made decent progress over the years balancing representation on our cohorts, there is more work to do. Given the nature of our peer-led programme, where we encourage our students to learn from each other, we can only achieve change if we continue to nurture an environment that includes a wide range of perspectives and experiences. 
+While we have made decent progress over the years balancing representation on our cohorts, there is more work to do. Given the nature of our peer-led programme, where we encourage our students to learn from each other, we can only achieve change if we continue to nurture an environment that includes a wide range of perspectives and experiences.
 
-We'd thought we'd include a non-exhaustive list of things we're looking forward to sharing with you come spring: 
+We'd thought we'd include a non-exhaustive list of things we're looking forward to sharing with you come spring:
 
 - Making our application process and curriculum more accessible;
 - Providing better mental health support for our students;
@@ -27,7 +27,7 @@ We'd thought we'd include a non-exhaustive list of things we're looking forward 
 - Continuing to grow our community to include more women, trans people, genderqueer people, younger people, older people, parents, and people from a much wider range of racial, ethnic and socioeconomic backgrounds;
 - Continuing to make sure people who are underrepresented in tech do not feel marginalised in our spaces.
 
-We understand you might be reasonably disappointed if you have been making good progress on our course prerequisites in preparation for the winter cohort, but we know that the time you have already put in is not time wasted at all. We will continue to support your learning journey through our Slack channels, and we look forward to seeing you very soon at our remote meetups!
+We understand you might be reasonably disappointed if you have been making good progress on our course requirements in preparation for the winter cohort, but we know that the time you have already put in is not time wasted at all. We will continue to support your learning journey through our Slack channels, and we look forward to seeing you very soon at our remote meetups!
 
 Lastly, to our alumni, thank you for all of your contribution over the years, and we look forward to creating this next chapter with your support.
 
@@ -35,11 +35,11 @@ We anticipate some questions might be asked regarding the apprenticeship, so her
 
 #### Am I eligible for an apprenticeship?
 
-If you have been ordinarily resident in the UK (or the EU or EEA, at least until 31 July 2021) for at least the previous three years and have the right to work in the UK, or have refugee status, you are eligible.  See the [Apprenticeship funding rules](https://www.gov.uk/guidance/apprenticeship-funding-rules-for-employer-providers/annex-a-eligibility-criteria-who-we-fund) for more details.
+If you have been ordinarily resident in the UK (or the EU or EEA, at least until 31 July 2021) for at least the previous three years and have the right to work in the UK, or have refugee status, you are eligible. See the [Apprenticeship funding rules](https://www.gov.uk/guidance/apprenticeship-funding-rules-for-employer-providers/annex-a-eligibility-criteria-who-we-fund) for more details.
 
 #### Does this change the application process?
 
-Yes and no. Applicants for apprenticeships will need to be interviewed by an employer and accepted onto an apprenticeship before attending our training programme. Applicants will still be expected to complete the prerequisites and attend a screening interview by us before being put forward to interview with an employer. 
+Yes and no. Applicants for apprenticeships will need to be interviewed by an employer and accepted onto an apprenticeship before attending our training programme. Applicants will still be expected to complete the application requirements and attend a screening interview by us before being put forward to interview with an employer.
 
 #### How will the selection criteria change?
 
@@ -67,8 +67,8 @@ We are still aiming for the spring start date of March 8, 2021.
 
 #### How long will the apprenticeship last?
 
-The apprenticeship is likely to last between 12 and 18 months with most of the training being completed in the first 4 months. 
+The apprenticeship is likely to last between 12 and 18 months with most of the training being completed in the first 4 months.
 
 #### What will apprentices be paid?
 
-This is still to be decided and may vary, but is likely to be in the range of £20-24,000, starting when the programme begins. 
+This is still to be decided and may vary, but is likely to be in the range of £20-24,000, starting when the programme begins.

--- a/src/pages/marketing/about.md
+++ b/src/pages/marketing/about.md
@@ -79,9 +79,9 @@ Founders and Coders is not your ordinary coding bootcamp. We’re on a mission t
 
   Yes, for insurance reasons you need to be 18.
 
-- ### How long will it take me to complete the prerequisites?
+- ### How long will it take me to complete the requirements?
 
-  How quickly you complete the prerequisites will depend on a variety of factors, such as technical background and time available. Our courses start three times a year so the next intake is never more than four months away.
+  How quickly you complete the application requirements will depend on a variety of factors, such as technical background and time available. Our courses start three times a year so the next intake is never more than four months away.
 
 - ### What happens in your interviews?
 

--- a/src/pages/marketing/apply.md
+++ b/src/pages/marketing/apply.md
@@ -53,9 +53,9 @@ Our programme is designed for people who are serious about a career in web devel
 
    Introduce yourself in our Slack workspace where you can find the most up-to-date information on our programme, meetups, and ask us any questions you may have.
 
-1. ### Start work on our course prerequisites
+1. ### Start work on the application requirements
 
-   While we don't like to suggest how long it will take you to complete the prerequisites, it's different for everyone, we expect you to take **at least three months** if you don't have any prior experience with web development.
+   While we don't like to suggest how long it will take you to complete the requirements, it's different for everyone, we expect you to take **at least three months** if you don't have any prior experience with web development.
 
    We encourage applicants to work through the material with other applicants, both online and through our meetups.
 
@@ -63,7 +63,7 @@ Our programme is designed for people who are serious about a career in web devel
 
    Plan to spend about an hour completing the application form.
 
-   If you submit your application before the deadline, keep working on the prerequisites and tidying up your website. We will evaluate your progress as of the date the window closes.
+   If you submit your application before the deadline, keep working on the requirements and tidying up your website. We will evaluate your progress as of the date the window closes.
 
 1. ### The conversational interview
 
@@ -92,9 +92,9 @@ Finding your own solutions to problems is an indispensable skill for a developer
 
 Founders and Coders will always prioritise marginalised people's safety over the comfort of the privileged. **If you don't like the sound of any of this then we'd ask you to reconsider your application.**
 
-## Course prerequisites
+## Application requirements
 
-**Before we will consider your application, you must complete the following prerequisites:**
+**Before we will consider your application, you must complete the following tasks:**
 
 ### Create a GitHub account
 
@@ -154,7 +154,7 @@ Your application website needs to be _written by you_ and it must fulfill **all*
 Your website _should_:
 
 - Be creative, show us with your _code_ who you are
-- Demonstrate your learnings from the prerequisites
+- Demonstrate your learnings from the requirements
 
 Your website _cannot_:
 


### PR DESCRIPTION
This term is clearer & will probably map better to the future of prereqs. Thanks for the prompt @yvonne-liu 

Just a simple swap for now—we can rewrite a bunch of copy later when we know what the new pre-req structure really looks like.