### PR TITLE
Uncheck checkboxes of incomplete kata

### DIFF
--- a/src/assets/js/checkCodewars.js
+++ b/src/assets/js/checkCodewars.js
@@ -39,6 +39,9 @@ content.querySelector("form").onsubmit = (event) => {
       return response.json();
     })
     .then(({ data }) => {
+      main
+        .querySelectorAll("input[type='checkbox']")
+        .forEach((box) => (box.checked = false));
       toggleCompleted(data);
     })
     .catch((error) => {


### PR DESCRIPTION
@yvonne-liu found a bug: the checkboxes were only ever additive, so if you searched my name (I've completed all but one) then a new person's it would keep showing them all checked.

This change resets them all to unchecked before updating with the new API data