### PR TITLE
Escape CoC HTML included in /slack page

### DIFF
--- a/src/documents/slack.md
+++ b/src/documents/slack.md
@@ -9,7 +9,7 @@ Please read and agree to our Code of Conduct before joining the community.
 
 ## {{collections.coc[0].data.title}}
 
-{{collections.coc[0].templateContent}}
+{{collections.coc[0].templateContent | safe}}
 
 </section>
 


### PR DESCRIPTION
This will probs be deleted v soon, but the fix is so easy we may as well merge for now.

Fix #90