### PR TITLE
Ensure home page title is enorme

### DIFF
--- a/src/_includes/layouts/marketing.njk
+++ b/src/_includes/layouts/marketing.njk
@@ -3,7 +3,7 @@ layout: layouts/base
 ---
 
 <main class="marketing">
-  <h1 class="{{ "giant-title" if permalink === "/"  }}">
+  <h1 class="{{ "giant-title" if page.url === "/"  }}">
     {{ title }}
   </h1>
   {{ content | safe }}


### PR DESCRIPTION
Just realised I broke this with the refactor the other day, sorry!

Marketing pages dont set the `permalink` data value anymore, so we should use the final `page.url` value in the logic to determine whether the page title should be large.