### PR TITLE
Put announcements in stories

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+  functions = "backend"
+  command = "npm run build"
+  
 [[headers]]
   for = "/sw.js"
   [headers.values]
@@ -23,6 +27,7 @@
   to = "https://fac-annual-report-2020.netlify.app/"
   status = 301
   
-[build]
-  functions = "backend"
-  command = "npm run build"
+[[redirects]]
+  from = "/announcements/application-requirements-changes/"
+  to = "/stories/application-requirements-changes/"
+  status = 301

--- a/src/_includes/components/story.njk
+++ b/src/_includes/components/story.njk
@@ -17,8 +17,9 @@
   </div>
   <div class="stack2 body">
     <h3>
-      {% if story.data.url %}
-        <a href="{{ story.data.url }}">{{ story.data.title }}</a>
+      {% set url = story.data.url or story.url %}
+      {% if url %}
+        <a href="{{ url }}">{{ story.data.title }}</a>
       {% else %}
         {{ story.data.title }}
       {% endif %}

--- a/src/announcements/announcements.json
+++ b/src/announcements/announcements.json
@@ -1,4 +1,0 @@
-{
-  "layout": "layouts/document",
-  "permalink": "announcements/{{ page.fileSlug }}/"
-}

--- a/src/stories/by-us/application-requirements-changes.md
+++ b/src/stories/by-us/application-requirements-changes.md
@@ -1,6 +1,9 @@
 ---
 title: Changes to our course requirements
 date: 2020-10-19
+page:
+  excerpt: We are making some changes to the work we require you to finish before applying to our programme. You can see the full updated requirements on our Apply page.
+tags: announcements
 ---
 
 We are making some changes to the work we require you to finish before applying to our programme. You can see the full updated requirements [on our Apply page](/apply/#application-requirements).

--- a/src/stories/stories.11tydata.js
+++ b/src/stories/stories.11tydata.js
@@ -1,0 +1,11 @@
+module.exports = {
+  layout: "layouts/document",
+  tags: ["stories"],
+  eleventyComputed: {
+    permalink: (data) => {
+      // external links don't need pages on our site
+      if (data.url) return false;
+      return `/stories/${data.page.fileSlug}/index.html`;
+    },
+  },
+};

--- a/src/stories/stories.json
+++ b/src/stories/stories.json
@@ -1,6 +1,0 @@
-{
-  "layout": "layouts/document",
-  "tags": [
-    "stories"
-  ]
-}


### PR DESCRIPTION
This is a stopgap until I get time to actually redesign a better blog. This stops announcements vanishing as soon as we stop linking to them—at least they're archived at /stories

<img width="1792" alt="Screenshot 2021-01-25 at 15 33 32" src="https://user-images.githubusercontent.com/9408641/105727156-b24f4b80-5f22-11eb-9851-0c13f0cb66db.png">
