### PR TITLE
Respect motion preferences

### DIFF
--- a/src/_includes/components/video.njk
+++ b/src/_includes/components/video.njk
@@ -1,3 +1,5 @@
 <div class="circle-reveal">
-  <video width="100%" src="{{video}}" muted autoplay loop></video>
+  <safer-autoplay>
+    <video class="circle-reveal" width="100%" src="{{video}}" muted controls loop></video>
+  </safer-autoplay>
 </div>

--- a/src/_includes/layouts/base.11ty.js
+++ b/src/_includes/layouts/base.11ty.js
@@ -86,28 +86,32 @@ module.exports = (data) => {
         ${Header({ pages, currentUrl: data.page.url })}${data.content}
         ${data.sticky && Sticky(data.sticky)}
         ${Footer({ nextPage, site: data.site })}
-      </body>
-      <script>
-        // remove all service workers (from the old site)
-        if (navigator.serviceWorker) {
-          navigator.serviceWorker
-            .getRegistrations()
-            .then(function (registrations) {
-              for (let registration of registrations) {
-                registration.unregister();
-              }
+        <script>
+          // remove all service workers (from the old site)
+          if (navigator.serviceWorker) {
+            navigator.serviceWorker
+              .getRegistrations()
+              .then(function (registrations) {
+                for (let registration of registrations) {
+                  registration.unregister();
+                }
+              });
+          }
+          // delete old cached files
+          if (caches) {
+            caches.keys().then(function (names) {
+              for (let name of names) caches.delete(name);
             });
-        }
-        // delete old cached files
-        if (caches) {
-          caches.keys().then(function (names) {
-            for (let name of names) caches.delete(name);
-          });
-        }
-      </script>
-      ${data.saveCheckboxes
-        ? html`<script src="/assets/js/checkboxes.js" type="module"></script>`
-        : ""}
+          }
+        </script>
+        ${data.saveCheckboxes
+          ? html`<script src="/assets/js/checkboxes.js" type="module"></script>`
+          : ""}
+        ${data.scripts &&
+        data.scripts.map(
+          (name) => `<script src="/assets/js/${name}.js"></script>`
+        )}
+      </body>
     </html>
   `;
 };

--- a/src/assets/js/safer-autoplay.js
+++ b/src/assets/js/safer-autoplay.js
@@ -1,0 +1,26 @@
+// Wrap around a video you want to autoplay.
+// Don't set the autoplay attribute,
+// since that can't respect user preferences.
+// e.g. <safer-autoplay><video src="vid.mp4"></video></safer-autoplay>
+
+class SaferAutoplay extends HTMLElement {
+  connectedCallback() {
+    const video = this.querySelector("video");
+
+    // check if user opted out of motion
+    const motionQuery = window.matchMedia("(prefers-reduced-motion)");
+
+    // play/pause depending on preference
+    function checkMotion() {
+      motionQuery.matches ? video.pause() : video.play();
+    }
+
+    // check on first load
+    checkMotion();
+
+    // re-check when preferences change
+    motionQuery.addEventListener("change", checkMotion);
+  }
+}
+
+window.customElements.define("safer-autoplay", SaferAutoplay);

--- a/src/index.md
+++ b/src/index.md
@@ -43,6 +43,8 @@ sticky:
   text: Applications are closed
   cta: Express interest
   href: https://docs.google.com/forms/d/e/1FAIpQLSepdNxKsrMjhfnbdkzKUgNpeWFmp8WLyiqTe_UY10TsPpFOEQ/viewform
+scripts:
+  - safer-autoplay
 ---
 
 {% include "components/video.njk" %}


### PR DESCRIPTION
We already had our CSS setup to disable animations if a user expressed that preference (e.g. because of vestibular disorders or just cause they don't like excess motion). However there's no way to stop videos autoplaying declaratively. This adds a simple Custom Element that wraps a video element and only autoplays it if the user has not expressed a preference for reduced motion.