### PR TITLE
Move Apprenticeship Guide from Notion

### DIFF
--- a/src/_includes/components/subnavLink.njk
+++ b/src/_includes/components/subnavLink.njk
@@ -1,0 +1,8 @@
+<a
+  href="{{ entry.url }}"
+  {% if page.url === entry.url %}
+  aria-current="page"
+  {% endif %}
+>
+  {{ entry.label }}
+</a>

--- a/src/_includes/layouts/document.njk
+++ b/src/_includes/layouts/document.njk
@@ -2,7 +2,12 @@
 layout: layouts/base
 ---
 
-<main class="layout {{ "marketing" if subnav else "document" }} flow">
+<main
+  class="layout document flow"
+  {% if subnav %}
+  style="--content-width: 64rem"
+  {% endif %}
+>
   <header
     class="layout--inherit layout--breakout flow stripes"
     style="--px: 0; --flow-space: var(--space2)"

--- a/src/_includes/layouts/document.njk
+++ b/src/_includes/layouts/document.njk
@@ -2,7 +2,7 @@
 layout: layouts/base
 ---
 
-<main class="layout document flow">
+<main class="layout {{ "marketing" if subnav else "document" }} flow">
   <header
     class="layout--inherit layout--breakout flow stripes"
     style="--px: 0; --flow-space: var(--space2)"
@@ -17,5 +17,31 @@ layout: layouts/base
     {% endif %}
     </div>
   </header>
-  {{ content | safe }}
+  {% if subnav %}
+    <div class="sidebar-layout">
+      <nav class="sidebar">
+        <ul class="subnav" role="list">
+          {% for entry in subnav %}
+            <li>
+              {% include '../components/subnavLink.njk' %}
+              {% if entry.children %}
+                <ul role="list">
+                  {% for entry in entry.children %}
+                    <li>
+                      {% include '../components/subnavLink.njk' %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+      <div class="content flow">
+        {{ content | safe }}
+      </div>
+    </div>
+  {% else %}
+    {{ content | safe }}
+  {% endif %}
 </main>

--- a/src/_includes/postcss/styles.postcss
+++ b/src/_includes/postcss/styles.postcss
@@ -1201,6 +1201,10 @@ input[aria-invalid="true"][aria-invalid="true"] {
   color: var(--red);
 }
 
+.document li + li {
+  margin-top: var(--space2);
+}
+
 .subnav {
   position: sticky;
   top: 1rem;

--- a/src/_includes/postcss/styles.postcss
+++ b/src/_includes/postcss/styles.postcss
@@ -146,7 +146,9 @@ ol {
 }
 
 ul[class],
-ol[class] {
+ul[role="list"],
+ol[class],
+ol[role="list"] {
   padding: 0;
   list-style: none;
 }
@@ -506,6 +508,21 @@ hr {
   --bg: var(--background);
   padding: var(--pad);
   background-color: var(--bg);
+}
+
+.sidebar-layout {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.sidebar {
+  flex-basis: 14rem;
+  flex-grow: 1;
+}
+
+.content {
+  flex-basis: 0;
+  flex-grow: 999;
 }
 
 .stripes {
@@ -1182,4 +1199,27 @@ input[aria-invalid="true"][aria-invalid="true"] {
 [data-validation] {
   font-size: 0.875em;
   color: var(--red);
+}
+
+.subnav {
+  position: sticky;
+  top: 1rem;
+}
+
+.subnav ul {
+  margin-top: 0;
+  padding-left: 1rem;
+}
+
+.subnav a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.subnav a[aria-current="page"] {
+  font-weight: bold;
+}
+
+.subnav a:hover {
+  text-decoration: underline;
 }

--- a/src/_includes/postcss/styles.postcss
+++ b/src/_includes/postcss/styles.postcss
@@ -521,6 +521,7 @@ hr {
 }
 
 .content {
+  min-width: 70%;
   flex-basis: 0;
   flex-grow: 999;
 }
@@ -1216,14 +1217,9 @@ input[aria-invalid="true"][aria-invalid="true"] {
 }
 
 .subnav a {
-  text-decoration: none;
   color: inherit;
 }
 
 .subnav a[aria-current="page"] {
   font-weight: bold;
-}
-
-.subnav a:hover {
-  text-decoration: underline;
 }

--- a/src/apprenticeship-guide/apprenticeship-guide.json
+++ b/src/apprenticeship-guide/apprenticeship-guide.json
@@ -1,0 +1,30 @@
+{
+  "layout": "layouts/document",
+  "subnav": [
+    {
+      "label": "For employers",
+      "url": "/apprenticeship-guide/for-employers/",
+      "children": [
+        {
+          "label": "Employer FAQs",
+          "url": "/apprenticeship-guide/employer-faqs/"
+        }
+      ]
+    },
+    {
+      "label": "For candidates",
+      "url": "/apprenticeship-guide/for-candidates/",
+      "children": [
+        {
+          "label": "Candidate FAQs",
+          "url": "/apprenticeship-guide/candidate-faqs/"
+        }
+      ]
+    },
+    { "label": "Schedule", "url": "/apprenticeship-guide/schedule/" },
+    {
+      "label": "Candidate journey",
+      "url": "/apprenticeship-guide/candidate-journey/"
+    }
+  ]
+}

--- a/src/apprenticeship-guide/candidate-faqs.md
+++ b/src/apprenticeship-guide/candidate-faqs.md
@@ -1,0 +1,30 @@
+---
+title: Candidate FAQs
+---
+
+**_What is the recommended apprentice salary?_**
+
+Our recommended apprentice starting salary is £24,000, paid from the beginning of your apprenticeship training, beginning in mid-April.
+
+**_Why aren't apprenticeships starting at the same time as the bootcamp?_**
+
+We need to prepare you for your interviews with employers. For our last coding bootcamp of 2020, interviews did not start until the 17th week of the full-time programme. This time we are splitting the programme into two parts: pre-apprenticeship bootcamp and apprenticeship training.
+
+**_How many employers have signed up to interview apprentice candidates?_**
+We will be releasing the initial list of employers in the first half of February and then updating it weekly.
+
+**What if I am still in full-time employment during the part-time pre-apprenticeship programme?**
+
+We will record any talks or workshops that you cannot attend and arrange the weekly tutorial sessions at a time when you are available.
+
+**_Can I continue to receive Universal Credit before securing an apprenticeship?_**
+The short answer is, "yes". The longer answer is that we can negotiate on your behalf with your Job Centre to ensure that there is no interruption in your payments while attending the pre-apprenticeship programme. You will need to contact us about this as soon as possible.
+
+**_What if I have not secured an apprenticeship by April 12th?_**
+You can continue on the programme regardless of whether you have secured an apprenticeship and we will continue to actively seek apprenticeship opportunities for you.
+
+**_Am I guaranteed an apprenticeship if I want one?_**
+We offer no guarantees of an apprenticeship, but we would not have accepted you onto this programme if we did not think you were capable of securing one and it is very much in our interests to secure you an apprenticeship as soon as we are able.
+
+**_When will I start being paid?_**
+You can usually expect your first salary to be paid at the end of the first calendar month in which you begin your apprenticeship. Exact details of payment may differ from employer to employer.

--- a/src/apprenticeship-guide/candidate-faqs.md
+++ b/src/apprenticeship-guide/candidate-faqs.md
@@ -2,29 +2,33 @@
 title: Candidate FAQs
 ---
 
-**_What is the recommended apprentice salary?_**
+- ### What is the recommended apprentice salary?
 
-Our recommended apprentice starting salary is £24,000, paid from the beginning of your apprenticeship training, beginning in mid-April.
+  Our recommended apprentice starting salary is £24,000, paid from the beginning of your apprenticeship training, beginning in mid-April.
 
-**_Why aren't apprenticeships starting at the same time as the bootcamp?_**
+- ### Why aren't apprenticeships starting at the same time as the bootcamp?
 
-We need to prepare you for your interviews with employers. For our last coding bootcamp of 2020, interviews did not start until the 17th week of the full-time programme. This time we are splitting the programme into two parts: pre-apprenticeship bootcamp and apprenticeship training.
+  We need to prepare you for your interviews with employers. For our last coding bootcamp of 2020, interviews did not start until the 17th week of the full-time programme. This time we are splitting the programme into two parts: pre-apprenticeship bootcamp and apprenticeship training.
 
-**_How many employers have signed up to interview apprentice candidates?_**
-We will be releasing the initial list of employers in the first half of February and then updating it weekly.
+- ### How many employers have signed up to interview apprentice candidates?
 
-**What if I am still in full-time employment during the part-time pre-apprenticeship programme?**
+  We will be releasing the initial list of employers in the first half of February and then updating it weekly.
 
-We will record any talks or workshops that you cannot attend and arrange the weekly tutorial sessions at a time when you are available.
+- ### What if I am still in full-time employment during the part-time pre-apprenticeship programme?\*\*
 
-**_Can I continue to receive Universal Credit before securing an apprenticeship?_**
-The short answer is, "yes". The longer answer is that we can negotiate on your behalf with your Job Centre to ensure that there is no interruption in your payments while attending the pre-apprenticeship programme. You will need to contact us about this as soon as possible.
+  sWe will record any talks or workshops that you cannot attend and arrange the weekly tutorial sessions at a time when you are available.
 
-**_What if I have not secured an apprenticeship by April 12th?_**
-You can continue on the programme regardless of whether you have secured an apprenticeship and we will continue to actively seek apprenticeship opportunities for you.
+- ### Can I continue to receive Universal Credit before securing an apprenticeship?
 
-**_Am I guaranteed an apprenticeship if I want one?_**
-We offer no guarantees of an apprenticeship, but we would not have accepted you onto this programme if we did not think you were capable of securing one and it is very much in our interests to secure you an apprenticeship as soon as we are able.
+  The short answer is, "yes". The longer answer is that we can negotiate on your behalf with your Job Centre to ensure that there is no interruption in your payments while attending the pre-apprenticeship programme. You will need to contact us about this as soon as possible.
 
-**_When will I start being paid?_**
-You can usually expect your first salary to be paid at the end of the first calendar month in which you begin your apprenticeship. Exact details of payment may differ from employer to employer.
+- ### What if I have not secured an apprenticeship by April 12th?
+
+  You can continue on the programme regardless of whether you have secured an apprenticeship and we will continue to actively seek apprenticeship opportunities for you.
+
+- ### Am I guaranteed an apprenticeship if I want one?
+
+  We offer no guarantees of an apprenticeship, but we would not have accepted you onto this programme if we did not think you were capable of securing one and it is very much in our interests to secure you an apprenticeship as soon as we are able.
+
+- ### When will I start being paid?
+  You can usually expect your first salary to be paid at the end of the first calendar month in which you begin your apprenticeship. Exact details of payment may differ from employer to employer.

--- a/src/apprenticeship-guide/candidate-journey.md
+++ b/src/apprenticeship-guide/candidate-journey.md
@@ -3,18 +3,17 @@ title: Candidate journey
 ---
 
 1. An interested candidate completes an expression of interest on our website;
-2. The candidate is invited to join our online forum for applicants and is invited to join a number of community events, workshops and meetups each month;
-3. The candidate starts work on the course entry requirements online; this process can take anything from 1 to 6 months of self-paced study;
+1. The candidate is invited to join our online forum for applicants and is invited to join a number of community events, workshops and meetups each month;
+1. The candidate starts work on the course entry requirements online; this process can take anything from 1 to 6 months of self-paced study;  
+   Alternatively, the candidate is referred onto our coaching programme through Islington Council’s Adult Community Learning website, where they will get ongoing support in completing the course entry requirements;
 
-Alternatively, the candidate is referred onto our coaching programme through Islington Council’s Adult Community Learning website, where they will get ongoing support in completing the course entry requirements;
-
-4. The candidate completes an application in the application window, which opens three times each year;
-5. The applicant is short-listed typically from over 50 applicants who have completed the course entry requirements (and over 1,200 candidates who have expressed interest in the programme in the previous year) for an interview and technical test, along with up to 31 other applicants;
-6. The candidate is offered a place on our pre-apprenticeship training programme along with 15 other successful candidates;
-7. After securing a place on the programme, the candidate joins a two-month pre-apprenticeship training, initially on a part-time basis for one month;
-8. The pre-apprenticeship programme ends with a one-month full-time bootcamp, focusing on software development fundamentals, interview preparation and employer engagement;
-9. Towards the end of the bootcamp, the candidates interview with employers for apprenticeships;
-10. After the candidate accepts an apprenticeship offer, the apprentice joins the company and starts the two-month apprenticeship training;
-11. If the learner does not immediately secure an apprenticeship, they may continue learning alongside the apprentices while we attempt to secure an apprenticeship for them;
-12. After two months' apprenticeship training, the apprentice joins their employer on a full-time basis;
-13. After 12 months, the apprentice completes their apprenticeship by passing an end-point assessment.
+1. The candidate completes an application in the application window, which opens three times each year;
+1. The applicant is short-listed typically from over 50 applicants who have completed the course entry requirements (and over 1,200 candidates who have expressed interest in the programme in the previous year) for an interview and technical test, along with up to 31 other applicants;
+1. The candidate is offered a place on our pre-apprenticeship training programme along with 15 other successful candidates;
+1. After securing a place on the programme, the candidate joins a two-month pre-apprenticeship training, initially on a part-time basis for one month;
+1. The pre-apprenticeship programme ends with a one-month full-time bootcamp, focusing on software development fundamentals, interview preparation and employer engagement;
+1. Towards the end of the bootcamp, the candidates interview with employers for apprenticeships;
+1. After the candidate accepts an apprenticeship offer, the apprentice joins the company and starts the two-month apprenticeship training;
+1. If the learner does not immediately secure an apprenticeship, they may continue learning alongside the apprentices while we attempt to secure an apprenticeship for them;
+1. After two months' apprenticeship training, the apprentice joins their employer on a full-time basis;
+1. After 12 months, the apprentice completes their apprenticeship by passing an end-point assessment.

--- a/src/apprenticeship-guide/candidate-journey.md
+++ b/src/apprenticeship-guide/candidate-journey.md
@@ -1,0 +1,20 @@
+---
+title: Candidate journey
+---
+
+1. An interested candidate completes an expression of interest on our website;
+2. The candidate is invited to join our online forum for applicants and is invited to join a number of community events, workshops and meetups each month;
+3. The candidate starts work on the course entry requirements online; this process can take anything from 1 to 6 months of self-paced study;
+
+Alternatively, the candidate is referred onto our coaching programme through Islington Council’s Adult Community Learning website, where they will get ongoing support in completing the course entry requirements;
+
+4. The candidate completes an application in the application window, which opens three times each year;
+5. The applicant is short-listed typically from over 50 applicants who have completed the course entry requirements (and over 1,200 candidates who have expressed interest in the programme in the previous year) for an interview and technical test, along with up to 31 other applicants;
+6. The candidate is offered a place on our pre-apprenticeship training programme along with 15 other successful candidates;
+7. After securing a place on the programme, the candidate joins a two-month pre-apprenticeship training, initially on a part-time basis for one month;
+8. The pre-apprenticeship programme ends with a one-month full-time bootcamp, focusing on software development fundamentals, interview preparation and employer engagement;
+9. Towards the end of the bootcamp, the candidates interview with employers for apprenticeships;
+10. After the candidate accepts an apprenticeship offer, the apprentice joins the company and starts the two-month apprenticeship training;
+11. If the learner does not immediately secure an apprenticeship, they may continue learning alongside the apprentices while we attempt to secure an apprenticeship for them;
+12. After two months' apprenticeship training, the apprentice joins their employer on a full-time basis;
+13. After 12 months, the apprentice completes their apprenticeship by passing an end-point assessment.

--- a/src/apprenticeship-guide/employer-faqs.md
+++ b/src/apprenticeship-guide/employer-faqs.md
@@ -2,39 +2,39 @@
 title: Employer FAQs
 ---
 
-**What is the recommended apprentice salary?**
+- ### What is the recommended apprentice salary?
 
-Our recommended apprentice starting salary is £24,000, paid from the beginning of their apprenticeship training, beginning in mid-April.
+  Our recommended apprentice starting salary is £24,000, paid from the beginning of their apprenticeship training, beginning in mid-April.
 
-**How long does the apprenticeship last?**
+- ### How long does the apprenticeship last?
 
-Not less than 12 months. It ends when the apprentice completes their end-point assessment.
+  Not less than 12 months. It ends when the apprentice completes their end-point assessment.
 
-**Who is responsible for the end-point assessment?**
+- ### Who is responsible for the end-point assessment?
 
-The [British Computer Society](https://www.bcs.org/develop-your-people/develop-your-team-or-organisation/digital-it-apprenticeships-for-your-team/bcs-end-point-assessment/).
+  The [British Computer Society](https://www.bcs.org/develop-your-people/develop-your-team-or-organisation/digital-it-apprenticeships-for-your-team/bcs-end-point-assessment/).
 
-**When will the apprentice expect a pay rise?**
+- ### When will the apprentice expect a pay rise?
 
-Certainly after they pass their end-point assessment. Possibly, while they are still doing their apprenticeship, if their preformance warrants it.
+  Certainly after they pass their end-point assessment. Possibly, while they are still doing their apprenticeship, if their preformance warrants it.
 
-**What additional support will you provide after the initial two-month block training?**
+- ### What additional support will you provide after the initial two-month block training?
 
-1. Regular monthly pastoral care for the apprentice from an assigned mentor
-2. Regular monthly checkins with the employer, or as requested
-3. Preparation for the end-point assessment
-4. Additional training in response to employer needs, as requested
+  1. Regular monthly pastoral care for the apprentice from an assigned mentor
+  1. Regular monthly checkins with the employer, or as requested
+  1. Preparation for the end-point assessment
+  1. Additional training in response to employer needs, as requested
 
-**Will there need to be any training in the second year?**
+- ### Will there need to be any training in the second year?
 
-If the end-point assessment is not completed within 12 months, then additional training may be desirable and necessary, equivalent to one day per week, to support the apprentice through their end-point assessment.
+  If the end-point assessment is not completed within 12 months, then additional training may be desirable and necessary, equivalent to one day per week, to support the apprentice through their end-point assessment.
 
-**How much does the training cost?**
+- ### How much does the training cost?
 
-The apprenticeship training is funded entirely by the apprenticeship levy and by levy transfers. If you need to access levy transfers, we can put you in touch with [London Progression Collaboration](https://www.thelpc.uk/), who can provide more information.
+  The apprenticeship training is funded entirely by the apprenticeship levy and by levy transfers. If you need to access levy transfers, we can put you in touch with [London Progression Collaboration](https://www.thelpc.uk/), who can provide more information.
 
-**Once we have used up our levy, can we still get levy transfer payments?**
+- ### Once we have used up our levy, can we still get levy transfer payments?
 
-If you are a levy payer, but only have a small sum in your levy fund, you can instead fund the apprenticeship through a levy transfer. We can put you in touch with [London Progression Collaboration](https://www.thelpc.uk/), who can provide more information.
+  If you are a levy payer, but only have a small sum in your levy fund, you can instead fund the apprenticeship through a levy transfer. We can put you in touch with [London Progression Collaboration](https://www.thelpc.uk/), who can provide more information.
 
 If you have any more questions, please contact [Dan](mailto:dan@foundersandcoders.com).

--- a/src/apprenticeship-guide/employer-faqs.md
+++ b/src/apprenticeship-guide/employer-faqs.md
@@ -1,0 +1,40 @@
+---
+title: Employer FAQs
+---
+
+**What is the recommended apprentice salary?**
+
+Our recommended apprentice starting salary is £24,000, paid from the beginning of their apprenticeship training, beginning in mid-April.
+
+**How long does the apprenticeship last?**
+
+Not less than 12 months. It ends when the apprentice completes their end-point assessment.
+
+**Who is responsible for the end-point assessment?**
+
+The [British Computer Society](https://www.bcs.org/develop-your-people/develop-your-team-or-organisation/digital-it-apprenticeships-for-your-team/bcs-end-point-assessment/).
+
+**When will the apprentice expect a pay rise?**
+
+Certainly after they pass their end-point assessment. Possibly, while they are still doing their apprenticeship, if their preformance warrants it.
+
+**What additional support will you provide after the initial two-month block training?**
+
+1. Regular monthly pastoral care for the apprentice from an assigned mentor
+2. Regular monthly checkins with the employer, or as requested
+3. Preparation for the end-point assessment
+4. Additional training in response to employer needs, as requested
+
+**Will there need to be any training in the second year?**
+
+If the end-point assessment is not completed within 12 months, then additional training may be desirable and necessary, equivalent to one day per week, to support the apprentice through their end-point assessment.
+
+**How much does the training cost?**
+
+The apprenticeship training is funded entirely by the apprenticeship levy and by levy transfers. If you need to access levy transfers, we can put you in touch with [London Progression Collaboration](https://www.thelpc.uk/), who can provide more information.
+
+**Once we have used up our levy, can we still get levy transfer payments?**
+
+If you are a levy payer, but only have a small sum in your levy fund, you can instead fund the apprenticeship through a levy transfer. We can put you in touch with [London Progression Collaboration](https://www.thelpc.uk/), who can provide more information.
+
+If you have any more questions, please contact [Dan](mailto:dan@foundersandcoders.com).

--- a/src/apprenticeship-guide/for-candidates.md
+++ b/src/apprenticeship-guide/for-candidates.md
@@ -1,0 +1,11 @@
+---
+title: For candidates
+---
+
+After applications close on January 10th, we will be inviting 32 candidates to interview with us January 18-22nd. Candidates will be notified by January 25th whether they have been successful in filling one of the 16 places on the programme.
+
+The FAC21 part-time pre-course starts in the first week of February and then goes full-time on March 8. The apprenticeship training starts on April 12. Throughout March and into April we will be holding interviews with employers. We expect programme participants to begin receiving apprentice offers from the end of March onwards.
+
+This is the first time that Founders and Coders has provided the option of taking an apprenticeship to our programme participants and it is the first time that many of our employers have offered apprenticeships.
+
+Our aim is to find an apprenticeship for every programme participant that wants one.

--- a/src/apprenticeship-guide/for-employers.md
+++ b/src/apprenticeship-guide/for-employers.md
@@ -1,0 +1,17 @@
+---
+title: For employers
+---
+
+What sets our apprenticeship apart is the size, quality and diversity of our applicant pool; the level of candidate preparation; and the quality of our training.
+
+We have selected 16 candidates drawn from a large pool of applicants. They started a pre-apprenticeship programme with us at the beginning of February that ends on April 10th. Apprenticeship interviews start in March. Once hired, apprentices start their apprenticeship training with us on April 13th and will then be ready to join their employers on June 14th.
+
+The _Founders and Coders_ apprenticeship training is recognised by the Education and Skills Funding Agency (ESFA). It follows the [Level 4 Software Developer apprenticeship standard](https://www.instituteforapprenticeships.org/media/4392/software-developer-st0116-standard.pdf), which we expect the apprentices to complete in 12 months, with most of the training taking place in the first two months of the apprenticeship.
+
+As with all apprenticeships, the apprentice is expected to spend at least 20% of their time engaged in off-the-job training. End-point assessments are carried out by the [British Computer Society](https://www.bcs.org/deliver-and-teach-qualifications/training-providers-and-adult-education-centres/deliver-digital-it-apprenticeships/end-point-assessment-for-training-providers/). There are no significant restrictions placed by the ESFA on the age of an apprentice or on their academic background.
+
+The _Founders and Coders_ programme follows the new Software Developer standard and focuses on the modern Web stack: JavaScript, HTML & CSS; Git; HTTP; testing; Node.js & Express; SQL & databases; APIs, authentication & security; continuous integration & deployment; SPAs & React.
+
+Immediately after the apprentice is hired, they start their apprenticeship training with us, before joining you on a full-time basis after two months. _Founders and Coders_ will continue to provide support to both employer and apprentice throughout the length of the apprenticeship until the apprentice is fully prepared for, and passes, their end-point assessment.
+
+We are partnering with the [London Progression Collaboration](https://www.thelpc.uk/) to keep the administrative burden on employers to a minimum. Through the LPC, employers who are not already paying the apprenticeship levy will be able to access funding to ensure that there will be no apprenticeship training fees to pay.

--- a/src/apprenticeship-guide/index.md
+++ b/src/apprenticeship-guide/index.md
@@ -1,0 +1,3 @@
+---
+title: Founders and Coders apprenticeship guide
+---

--- a/src/apprenticeship-guide/schedule.md
+++ b/src/apprenticeship-guide/schedule.md
@@ -1,0 +1,3 @@
+# Schedule
+
+[Spring 2021 cohort](Schedule%208e08ec20c52d4fe5b8175b37b1e2315d/Spring%202021%20cohort%200b8b887b060c44cd84d9f6b16c59e059.csv)

--- a/src/apprenticeship-guide/schedule.md
+++ b/src/apprenticeship-guide/schedule.md
@@ -1,3 +1,14 @@
-# Schedule
+---
+title: Apprenticeships Schedule
+---
 
-[Spring 2021 cohort](Schedule%208e08ec20c52d4fe5b8175b37b1e2315d/Spring%202021%20cohort%200b8b887b060c44cd84d9f6b16c59e059.csv)
+- ### Pre-apprenticeship programme, part-time
+  Feb 3 2021-Mar 5 2021
+- ### Pre-apprenticeship programme, full-time
+  Mar 8 2021-Apr 9 2021
+- ### Apprenticeship interviews
+  Mar 17 2021-Apr 9 2021
+- ### Apprenticeship training
+  Apr 12 2021-Jun 11 2021
+- ### Apprentices join employers
+  Jun 14 2021


### PR DESCRIPTION
- [x] Move apprenticeship guide content from Notion
- [x] Clean up Notion Markdown
- [x] Create optional sidebar subnav for document directories
  - Currently the nav content is hard-coded in a JSON file within the directory. Ideally this could be generated by the directory structure but that's kinda complex to do.
  - Also the subnav only supports one level of nesting because Nunjucks templates can't be recursive 😅. So I had to hard-code the nested loop

I wasn't really sure what to do with the "index" page—on Notion it's just a list of links, which is already provided by the subnav here. I left it blank for now, which looks a bit weird 🤷. Maybe we should write an intro or something there just to have something to fill the space?

<img width="1792" alt="Screenshot 2021-02-19 at 13 11 15" src="https://user-images.githubusercontent.com/9408641/108508613-fb8d8380-72b3-11eb-84ea-2badec28cb5f.png">

<img width="1792" alt="Screenshot 2021-02-19 at 13 11 22" src="https://user-images.githubusercontent.com/9408641/108508622-fdefdd80-72b3-11eb-9df6-a9dd98b1d04e.png">

Fix #109 