### PR TITLE
Remove global CSS rule making first paragraph big

### DIFF
--- a/src/_includes/postcss/styles.postcss
+++ b/src/_includes/postcss/styles.postcss
@@ -351,14 +351,6 @@ button {
 }
 
 .marketing {
-  & > p:first-of-type {
-    --flow-space: var(--space5);
-    font-size: var(--font4);
-
-    @media (--viewport-xs) {
-      font-size: var(--font5);
-    }
-  }
   & h2,
   & hr,
   & .circle-reveal,


### PR DESCRIPTION
This used to be needed but the opening paragraph on each page is now in the stripey header.

Fixes a bug where a random paragraph halfway down /apply is accidentally massive.

## Before

<img width="1125" alt="Screenshot 2021-02-23 at 15 00 01" src="https://user-images.githubusercontent.com/9408641/108862128-d9637080-75e7-11eb-86b7-6204fdb57495.png">

## After

<img width="1125" alt="Screenshot 2021-02-23 at 15 00 13" src="https://user-images.githubusercontent.com/9408641/108862150-dcf6f780-75e7-11eb-8045-bc34e161584b.png">

Credit to @yvonne-liu for spotting this