### PR TITLE
Fix Codewars checker

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,8 @@
   from = "/announcements/application-requirements-changes/"
   to = "/stories/application-requirements-changes/"
   status = 301
+
+[[redirects]]
+  from = "/codewars/*"
+  to = "https://www.codewars.com/api/v1/:splat"
+  status = 200

--- a/src/assets/js/checkCodewars.js
+++ b/src/assets/js/checkCodewars.js
@@ -27,9 +27,7 @@ content.querySelector("form").onsubmit = (event) => {
   errorEl.textContent = "";
   loadingEl.hidden = false;
 
-  fetch(
-    `https://cors-anywhere.herokuapp.com/https://www.codewars.com/api/v1/users/${username}/code-challenges/completed`
-  )
+  fetch(`/codewars/users/${username}/code-challenges/completed`)
     .then((response) => {
       if (!response.ok) {
         const error = new Error("HTTP Error");


### PR DESCRIPTION
Use [Netlify redirects](https://docs.netlify.com/routing/redirects/rewrites-proxies/#proxy-to-another-service) as a proxy to bypass Codewars API CORS errors.

CORS Anywhere disabled their API so we can't use that anymore.