### PR TITLE
Put apprenticeship page title in metadata

### DIFF
--- a/src/documents/apprenticeships.md
+++ b/src/documents/apprenticeships.md
@@ -1,4 +1,6 @@
-# Software Developer Apprenticeships with Founders and Coders
+---
+title: Software Developer Apprenticeships
+---
 
 **We are launching a Software Developer Apprenticeship allowing employers to hire developers without hiring fees.**
 


### PR DESCRIPTION
We use the title data property to populate the page `<title>` and also the stripey section at the top. Putting the title directly in the markdown makes it look kinda broken