### PR TITLE
Make email comparisons case-insensitive

### DIFF
--- a/backend/forms/utils.js
+++ b/backend/forms/utils.js
@@ -1,0 +1,8 @@
+async function getByEmail(client, email, fields) {
+  return client
+    .select({ fields })
+    .all()
+    .find((r) => r.fields.email.toLowerCase() === email.toLowerCase());
+}
+
+module.exports = { getByEmail };

--- a/backend/forms/validators/express-interest.js
+++ b/backend/forms/validators/express-interest.js
@@ -1,3 +1,5 @@
+const { getByEmail } = require("../utils.js");
+
 let nono = {
   apprenticeship: ["No, I am not eligible for an apprenticeship in the UK"],
   age: ["No, I am not over 18 years old"],
@@ -29,14 +31,7 @@ module.exports = async ({ data, db, table }) => {
       invalidData: { residence },
     };
   }
-  let prevEmails = await db(table)
-    .select({
-      fields: ["email"],
-    })
-    .all();
-  let existing = prevEmails.find(
-    (record) => record.fields.email === data.email
-  );
+  let existing = getByEmail(db(table), data.email, ["email"]);
   if (existing) {
     return { errorPage: "/error/duplicate/", shouldSave: false };
   }

--- a/backend/forms/validators/tribute.js
+++ b/backend/forms/validators/tribute.js
@@ -1,3 +1,5 @@
+const { getByEmail } = require("../utils.js");
+
 module.exports = async ({ data, db, table }) => {
   let existing = await getByEmail(db(table), data.email, ["email"]);
   if (existing) {
@@ -6,17 +8,8 @@ module.exports = async ({ data, db, table }) => {
 
   let eoi = await getByEmail(db("EOI"), data.email, ["email", "name"]);
   if (!eoi) {
-    return { errorPage: "/error/missing-eoi/", shouldSaveL: false };
+    return { errorPage: "/error/missing-eoi/", shouldSave: false };
   }
 
   return { shouldSave: true, linkedData: { id: eoi.id, ...eoi.fields } };
 };
-
-async function getByEmail(client, email, fields) {
-  let records = await client
-    .select({
-      fields,
-    })
-    .all();
-  return records.find((record) => record.fields.email === email);
-}


### PR DESCRIPTION
Technically emails _can_ be case-sensitive, but in practice almost all providers avoid this so it should be safe to just lowercase and compare.

In future we should really avoid using emails as a UID altogether by having a proper database and logged in users that we can identify directly.

Also share the logic for retrieving Airtable records by email, so we only have to fix stuff in one place.